### PR TITLE
chore: alert-when-popup-failed-to-open

### DIFF
--- a/src/communication/popup.ts
+++ b/src/communication/popup.ts
@@ -13,6 +13,7 @@ export function openPopup(url: URL): Window {
   );
   popup?.focus();
   if (!popup) {
+    alert("Please enable pop-ups to continue");
     throw new Error("WebApp window failed to open");
   }
 


### PR DESCRIPTION
Most browsers block pop-up windows by default, so users need to be reminded to modify their settings.

![image](https://github.com/user-attachments/assets/7e49cc84-2a15-4fb0-b280-d4065d36a7c7)
