### PR TITLE
fix: handle request accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
   "devDependencies": {
     "@types/node": "^22.7.3"
   },
-  "version": "0.0.23"
+  "version": "0.0.24"
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -72,6 +72,7 @@ export class HoTProvider
   private readonly communicator: Communicator;
   private accounts: string[] = [];
   private chain: Chain;
+  public readonly isHoT = true;
 
   constructor(options: { url?: string }) {
     super();
@@ -159,9 +160,9 @@ export class HoTProvider
   private async handleRequestAccounts(
     request: RequestArguments
   ): Promise<unknown> {
-    if (this.accounts.length > 0) {
-      return this.accounts;
-    }
+    // if (this.accounts.length > 0) {
+    //   return this.accounts;
+    // }
     const result = (await this.sendRequestToPopup(request)) as {
       accounts: string[];
       availableChainList: Chain[];

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -60,6 +60,7 @@ type Chain = {
 };
 
 export const HoTUrl = [
+  "http://web.token.im/",
   "https://home-of-token-web.vercel.app/", // main
   "https://web.imstaging.works/", // staging
   "https://home-of-token-web-test.vercel.app/", // test


### PR DESCRIPTION
accounts 被缓存导致先前 dev 用户在 staging 建立连接时一直用到 dev 的 account，同理到时候 staging 切到 prod 时也会遇到这个问题，先做个快速修复。
另外增加 isHoT 帮助 DApp 确认当前连接 provider 时 HoT